### PR TITLE
Added 'ratchet' specification directive.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 build
 dist
 seqgen.egg-info
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ optional arguments:
                         100)
 ```
 
-## Sequence spefication
+## Sequence specification
 
 Your JSON specifies what sequences you want created.
 
@@ -148,6 +148,11 @@ specification keys you can put in a object in the JSON is as follows:
   an internal name.
 * `random aa`: The sequence should be made of random amino acids.
 * `random nt`: The sequence should be made of random nucleotides.
+* `ratchet`: If `true` and a count and mutation rate are given, sequences
+  after the first will be mutants of the previous sequence. This can be
+  used to build a series of sequences that are successive mutants of one
+  another. For the name derivation, see
+  [Muller's Ratchet](https://en.wikipedia.org/wiki/Muller's_ratchet).
 * `sections`: Gives a list of sequence sections used to build up another
   sequence (see example above). Each section is a JSON object that may
   contain the keys present in a regular sequence object, excluding `count`,

--- a/seqgen/__init__.py
+++ b/seqgen/__init__.py
@@ -2,6 +2,6 @@ from seqgen.sequences import Sequences
 
 # Note that the version string must have the following format, otherwise it
 # will not be found by the version() function in ../setup.py
-__version__ = '1.0.10'
+__version__ = '1.0.11'
 
 __all__ = ['Sequences']


### PR DESCRIPTION
I ended up calling it `ratchet` in a historical nod to Muller.

Fixes #1 
